### PR TITLE
Add ceo as owner of import even if there's no owner in spreadsheet

### DIFF
--- a/cass.import/src/main/java/org/cass/importer/CTDLASNCSVConceptImport.java
+++ b/cass.import/src/main/java/org/cass/importer/CTDLASNCSVConceptImport.java
@@ -137,11 +137,11 @@ public class CTDLASNCSVConceptImport {
                                             if (JSObjectAdapter.$get(e, "owner") != null) {
                                                 EcIdentity id = new EcIdentity();
                                                 id.ppk = EcPpk.fromPem((String) JSObjectAdapter.$get(e, "owner"));
-                                                if (ceo != null)
-                                                    f.addOwner(ceo.ppk.toPk());
                                                 f.addOwner(id.ppk.toPk());
                                                 EcIdentityManager.addIdentityQuietly(id);
                                             }
+                                            if (ceo != null)
+                                                f.addOwner(ceo.ppk.toPk());
                                             JSObjectAdapter.$put(f, "schema:dateModified", new Date().toISOString());
 
                                             if (EcConceptScheme.template != null && JSObjectAdapter.$get(EcConceptScheme.template,("schema:dateCreated")) != null) {
@@ -186,12 +186,12 @@ public class CTDLASNCSVConceptImport {
                                             if (JSObjectAdapter.$get(e, "owner") != null) {
                                                 EcIdentity id = new EcIdentity();
                                                 id.ppk = EcPpk.fromPem((String) JSObjectAdapter.$get(e, "owner"));
-                                                if (ceo != null)
-                                                    f.addOwner(ceo.ppk.toPk());
                                                 if (id.ppk != null)
                                                     f.addOwner(id.ppk.toPk());
                                                 EcIdentityManager.addIdentityQuietly(id);
                                             }
+                                            if (ceo != null)
+                                                f.addOwner(ceo.ppk.toPk());
 
                                             if (EcConcept.template != null && JSObjectAdapter.$get(EcConcept.template,("schema:dateCreated")) != null) {
                                                 CTDLASNCSVImport.setDateCreated(e, f);

--- a/cass.import/src/main/java/org/cass/importer/CTDLASNCSVImport.java
+++ b/cass.import/src/main/java/org/cass/importer/CTDLASNCSVImport.java
@@ -128,11 +128,11 @@ public class CTDLASNCSVImport {
 											if (JSObjectAdapter.$get(e, "owner") != null) {
 												EcIdentity id = new EcIdentity();
 												id.ppk = EcPpk.fromPem((String) JSObjectAdapter.$get(e, "owner"));
-												if (ceo != null)
-													f.addOwner(ceo.ppk.toPk());
 												f.addOwner(id.ppk.toPk());
 												EcIdentityManager.addIdentityQuietly(id);
 											}
+											if (ceo != null)
+												f.addOwner(ceo.ppk.toPk());
 
 											if (EcFramework.template != null && JSObjectAdapter.$get(EcFramework.template,("schema:dateCreated")) != null) {
 												setDateCreated(e, f);
@@ -205,12 +205,12 @@ public class CTDLASNCSVImport {
 											EcIdentity id = new EcIdentity();
 											if (JSObjectAdapter.$get(e, "owner") != null) {
 												id.ppk = EcPpk.fromPem((String) JSObjectAdapter.$get(e, "owner"));
-												if (ceo != null)
-													f.addOwner(ceo.ppk.toPk());
 												if (id.ppk != null)
 													f.addOwner(id.ppk.toPk());
 												EcIdentityManager.addIdentityQuietly(id);
 											}
+											if (ceo != null)
+												f.addOwner(ceo.ppk.toPk());
 
 											if (EcCompetency.template != null && JSObjectAdapter.$get(EcCompetency.template,("schema:dateCreated")) != null) {
 												setDateCreated(e, f);


### PR DESCRIPTION
The owner was previously being added in the editor before each object was saved, but now that we're using multiput it needs to happen in the libraries.